### PR TITLE
readme: add distrobox to the tools list

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -47,6 +47,7 @@ These should be enough to get you started.
 ## Tools and other rando things that are worth looking at
 
 - [Toolbx](https://github.com/containers/toolbox) - Tool for containerized command line environments on Linux 
+- [Distrobox](https://github.com/89luca89/distrobox) - Tool for containerized command line environments on Linux, distribution agnostic, supports a wide variety of containers , works both with podman and docker
 - [podman](https://podman.io/) - Podman is a daemonless container engine for developing, managing, and running OCI Containers on your Linux System.
   - :new: [gnome-shell-extension-containers](https://github.com/rgolangh/gnome-shell-extension-containers) - This neat extension lets you see what containers you have, start/stop/restart, pause, and shell into them right from the notification area.
   - :new: [Podman desktop companion](https://iongion.github.io/podman-desktop-companion/) - graphical management of your desktop containers


### PR DESCRIPTION
Hi @castrojo 
if it was of interest I would like to add to the list my project `distrobox` , you can find it here: https://github.com/89luca89/distrobox

Main outline: it is a `toolbx` alternative which is both distribution agnostic both on the host side and on the container side, allowing the use of almost any distribution's container without the need of building a specifically crafted image. There is a table of support where all tested images are validated and tested.
It supports both podman and docker and includes an utility to integrate apps, binaries and service back with the host

Hope it is of interest, if not let me know I'll just close the PR :+1: 
bye!