### PR TITLE
Updated link to not return 404

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -48,7 +48,7 @@ The Future is Now(tm), try one of these today!
 - [ChromeOS Flex](https://chromeenterprise.google/os/chromeosflex/) - the cloud-first, fast, easy-to-manage, and secure Chrome OS for PCs and Macs. 
   - [ChromiumOS](https://www.chromium.org/chromium-os/chromiumos-design-docs/filesystem-autoupdate/) - Good design document on how Chromium implements its autoupdate mechanism
 - [rlxos](https://rlxos.dev/) - A immutable, independent general-purpose distribution with primary focus on single file per application.
-- [carbonOS](https://carbon.sh/) - An open operating system designed from the ground-up to be intuitive and robust. The [blog post](https://carbon.sh/blog/2021/11/25/release.html) explains the goals
+- [carbonOS](https://carbon.sh/) - An open operating system designed from the ground-up to be intuitive and robust. The [blog post](https://carbon.sh/blog/2021-11-25-release.html) explains the goals
 
 ## Toolboxes
 


### PR DESCRIPTION
The link to the carbonOS blog post containing the rationale sent me to a 404, but I think I found the blog post in question and fixed the link. They changed the URL to a different scheme.