### PR TITLE
add Nitrux OS

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -54,6 +54,7 @@ The Future is Now(tm), try one of these today!
 - [carbonOS](https://carbon.sh/) - An open operating system designed from the ground-up to be intuitive and robust. The [blog post](https://carbon.sh/blog/2021-11-25-release.html) explains the goals
 - [AshOS](https://github.com/ashos/ashos) - The immutable tree-shaped meta-distribution.
 - [VanillaOS](https://vanillaos.org/) - Vanilla OS is an Ubuntu Linux-based Point Release distribution that receives updates at the right time, neither before nor after, without sacrificing security and functionality.
+- [Nitrux OS](https://nxos.org/) ([2.6.0](https://nxos.org/changelog/release-announcement-nitrux-2-6-0/)+) - A Debian-based Linux distribution that features [NX Desktop](https://nxos.org/english/nxd/) and the [MauiKit Applications](https://mauikit.org/) suite.
 
 ## Toolboxes
 


### PR DESCRIPTION
Apparently since the very-recently-released 2.6.0, the base OS have been immutable and tools like dpkg, APT, and PackageKit are no longer available to use.

ref: https://nxos.org/notes/notes-nitrux-2-6-0/#working-with-overlayroot-in-nitrux