### PR TITLE
readme: add folderbox to toolboxes

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -71,6 +71,7 @@ Someone smarter please make a better definition.
 - [nsbox](https://github.com/refi64/nsbox) - Pet container manager based on systemd-nspawn and supporting DBus and desktop files.
 - [unbox](https://github.com/lopukhov/unbox) - New (a little bit experimental) implementation of a toolbox that does not rely on existing container engines like `podman` or `docker`, instead opting to use Linux namespaces directly to improve performance.
 - [coretoolbox](https://github.com/cgwalters/coretoolbox) - Toolbx alternative in rust with a focus on container builds. (Older project, appears unmaintained, but if I don't include rust stuff people will get upset :smiley:)
+- [folderbox](https://github.com/ahayzen/folderbox) - Folder based containers that isolate project environments with escapes to the host for development
 
 ## Core Tools
 


### PR DESCRIPTION
Wonder if a tool ( https://github.com/ahayzen/folderbox ) i've been writing to aid development on immutable OSes would be useful for your list.

I use it so that each customer project has it's own isolated container and persistent space, then i can run the container and even attach to it with vscode etc.

It's somewhere between distrobox, devbox, and x11docker. As it has boxes that you can run against a project folder (either a shared one defined centrally or defined within the project), so it's not exposing all of HOME, it automatically connects many sandbox escapes for GUIs, gdb, audio etc, and it is using OCI images rather than nix.