### PR TITLE
Remove the link to the Immutable Linux Discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,6 @@ Here are some people walking through their setups:
 	- [r/flatpak](https://www.reddit.com/r/flatpak/)
 
 - Discord Servers:
-	- [Immutable Linux Discord](https://discord.gg/N4mswFw6ds)
 	- [Universal Blue Discord](https://discord.gg/Xsk7n54fFY)
 	- [NixOS Discord](https://discord.gg/RbvHtGa)
 	- [VanillaOS Discord](https://discord.gg/vanilla-os-1023243680829681704)


### PR DESCRIPTION
This Discord is a graveyard and it would be better to direct others to the specific niche that they're interested in like communities centered around the operating system they're using specifically, not a generalized central area where users of NixOS, Fedora Atomic, OpenSUSE Aeon/Kalpa/MicroOS, VanillaOS, EndlessOS, etc. are in one place.  

This Discord has served its purpose long ago in my opinion and it was a small community with several members who went on to contribute to projects that benefit the greater desktop Linux.  There is information archived in the channels here that I should look over and eventually document to the projects that it pertains to if not outdated and relevant.