### PR TITLE
feat: SecureBlue, WayBlue

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ The Future is Now™, try one of these today!
 		- Community & Downstream OCI Projects - These projects are built using Universal Blue infrastructure or base images and utilize BlueBuild to provide specialized versions of the uBlue stack.
 			- [SecureBlue](https://github.com/secureblue/secureblue) - A security-hardened project that adds kernel hardening, a hardened memory allocator (from GrapheneOS), and reduced attack surfaces to the Fedora Atomic/uBlue base.
 			- [WayBlue](https://github.com/wayblueorg/wayblue) - A community-driven collection of images providing lean, minimally-opinionated Wayland window managers (Hyprland, Sway, River, Niri) built on the uBlue framework.
+		- Independent Fedora Atomic Distributions - These projects leverage Fedora’s OCI/bootc technology but are entirely independent of Universal Blue and have unique architectural philosophies.
+			- [RakuOS](https://github.com/RakuOS) - A highly active "Hybrid Atomic" distribution. It utilizes the performance-optimized **CachyOS kernel** and SCX schedulers. Unlike standard atomic distros, it features a unique persistent overlay that allows users to instantly install native packages via `dnf` without relying on slow `rpm-ostree` layering. Available in KDE, GNOME, and COSMIC.
+			- [Origami Linux](https://origami.wf/) - An opinionated, aesthetics-focused distribution featuring the COSMIC desktop and also powered by the **CachyOS kernel**. Designed as a "container-first" developer environment, it explicitly replaces standard legacy shell utilities with blazing-fast Rust alternatives (like `eza`, `bat`, and `ripgrep`) out of the box.
 - openSUSE Atomic
 	- [openSUSE MicroOS](https://microos.opensuse.org/) - An atomic variant of openSUSE for servers
 	- [openSUSE Aeon](https://aeondesktop.org) - An atomic variant of openSUSE with the GNOME desktop environment, featuring containers with Distrobox.

--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ The Future is Now™, try one of these today!
 			- [Bluefin](https://projectbluefin.io/) - An Universal Blue OCI image focused on general and development use, based on [Fedora Silverblue](https://fedoraproject.org/atomic-desktops/silverblue)
 			- [Aurora](https://getaurora.dev/) - An Universal Blue OCI image focused on general and development use, based on [Fedora Kinoite](https://fedoraproject.org/atomic-desktops/kinoite/)
 			- [uCore](https://projectucore.io/) - An Universal Blue OCI image focused on server use, based on [Fedora CoreOS](https://fedoraproject.org/coreos/)
-		- Community & Downstream OCI Projects - These projects are built using Universal Blue infrastructure or base images and utilize BlueBuild to provide specialized versions of the uBlue stack.
-			- [SecureBlue](https://github.com/secureblue/secureblue) - A security-hardened project that adds kernel hardening, a hardened memory allocator (from GrapheneOS), and reduced attack surfaces to the Fedora Atomic/uBlue base.
-			- [WayBlue](https://github.com/wayblueorg/wayblue) - A community-driven collection of images providing lean, minimally-opinionated Wayland window managers (Hyprland, Sway, River, Niri) built on the uBlue framework.
+		- Community & Downstream OCI Projects - These projects are built using Universal Blue infrastructure or base images and utilize BlueBuild to provide specialized versions of the uBlue stack
+			- [SecureBlue](https://github.com/secureblue/secureblue) - A security-hardened project that adds kernel hardening, a hardened memory allocator (from GrapheneOS), and reduced attack surfaces to the Fedora Atomic/uBlue base
+			- [WayBlue](https://github.com/wayblueorg/wayblue) - A community-driven collection of images providing lean, minimally-opinionated Wayland compositors (Hyprland, Sway, River, Niri, …) built on the uBlue framework
 - openSUSE Atomic
 	- [openSUSE MicroOS](https://microos.opensuse.org/) - An atomic variant of openSUSE for servers
 	- [openSUSE Aeon](https://aeondesktop.org) - An atomic variant of openSUSE with the GNOME desktop environment, featuring containers with Distrobox.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ The Future is Now™, try one of these today!
 			- [Bluefin](https://projectbluefin.io/) - An Universal Blue OCI image focused on general and development use, based on [Fedora Silverblue](https://fedoraproject.org/atomic-desktops/silverblue)
 			- [Aurora](https://getaurora.dev/) - An Universal Blue OCI image focused on general and development use, based on [Fedora Kinoite](https://fedoraproject.org/atomic-desktops/kinoite/)
 			- [uCore](https://projectucore.io/) - An Universal Blue OCI image focused on server use, based on [Fedora CoreOS](https://fedoraproject.org/coreos/)
+		- Community & Downstream OCI Projects - These projects are built using Universal Blue infrastructure or base images and utilize BlueBuild to provide specialized versions of the uBlue stack.
+			- [SecureBlue](https://github.com/secureblue/secureblue) - A security-hardened project that adds kernel hardening, a hardened memory allocator (from GrapheneOS), and reduced attack surfaces to the Fedora Atomic/uBlue base.
+			- [WayBlue](https://github.com/wayblueorg/wayblue) - A community-driven collection of images providing lean, minimally-opinionated Wayland window managers (Hyprland, Sway, River, Niri) built on the uBlue framework.
 - openSUSE Atomic
 	- [openSUSE MicroOS](https://microos.opensuse.org/) - An atomic variant of openSUSE for servers
 	- [openSUSE Aeon](https://aeondesktop.org) - An atomic variant of openSUSE with the GNOME desktop environment, featuring containers with Distrobox.

--- a/README.md
+++ b/README.md
@@ -59,9 +59,6 @@ The Future is Now™, try one of these today!
 		- Community & Downstream OCI Projects - These projects are built using Universal Blue infrastructure or base images and utilize BlueBuild to provide specialized versions of the uBlue stack.
 			- [SecureBlue](https://github.com/secureblue/secureblue) - A security-hardened project that adds kernel hardening, a hardened memory allocator (from GrapheneOS), and reduced attack surfaces to the Fedora Atomic/uBlue base.
 			- [WayBlue](https://github.com/wayblueorg/wayblue) - A community-driven collection of images providing lean, minimally-opinionated Wayland window managers (Hyprland, Sway, River, Niri) built on the uBlue framework.
-		- Independent Fedora Atomic Distributions - These projects leverage Fedora’s OCI/bootc technology but are entirely independent of Universal Blue and have unique architectural philosophies.
-			- [RakuOS](https://github.com/RakuOS) - A highly active "Hybrid Atomic" distribution. It utilizes the performance-optimized **CachyOS kernel** and SCX schedulers. Unlike standard atomic distros, it features a unique persistent overlay that allows users to instantly install native packages via `dnf` without relying on slow `rpm-ostree` layering. Available in KDE, GNOME, and COSMIC.
-			- [Origami Linux](https://origami.wf/) - An opinionated, aesthetics-focused distribution featuring the COSMIC desktop and also powered by the **CachyOS kernel**. Designed as a "container-first" developer environment, it explicitly replaces standard legacy shell utilities with blazing-fast Rust alternatives (like `eza`, `bat`, and `ripgrep`) out of the box.
 - openSUSE Atomic
 	- [openSUSE MicroOS](https://microos.opensuse.org/) - An atomic variant of openSUSE for servers
 	- [openSUSE Aeon](https://aeondesktop.org) - An atomic variant of openSUSE with the GNOME desktop environment, featuring containers with Distrobox.


### PR DESCRIPTION
## Changes

I have added the following Fedora Atomic projects to the list, categorized by their relationship to the Universal Blue ecosystem and their unique architectural philosophies:

1. **SecureBlue**: Added under `Community & Downstream OCI Projects`. Focuses on security hardening, utilizing kernel hardening and GrapheneOS's hardened memory allocator.
2. **WayBlue**: Added under `Community & Downstream OCI Projects`. A collection of lean, Wayland-based window manager images (Hyprland, Sway, etc.) built on the uBlue framework.

## Closes

Closes #100
Closes #99